### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,14 +13,14 @@ getpH	KEYWORD2
 getTemperature	KEYWORD2
 getCalibrationPoint	KEYWORD2
 getCalibrationValue	KEYWORD2
-getpHStableCount    KEYWORD2
-getSumOfDeltaValue  KEYWORD2
-getDeltaValue   KEYWORD2
-getPrecision    KEYWORD2
-getDefaultSlope KEYWORD2
-getDefaultAdcAt7    KEYWORD2
+getpHStableCount	KEYWORD2
+getSumOfDeltaValue	KEYWORD2
+getDeltaValue	KEYWORD2
+getPrecision	KEYWORD2
+getDefaultSlope	KEYWORD2
+getDefaultAdcAt7	KEYWORD2
 
 ispHStable	KEYWORD2
 setpHPrecision	KEYWORD2
-setDefaultSlope KEYWORD2
-setDefaultAdcAt7    KEYWORD2
+setDefaultSlope	KEYWORD2
+setDefaultAdcAt7	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords